### PR TITLE
Fix type on next cursor

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -68,5 +68,5 @@ export {
  * */
 export type Paginated<T> = {
   items: T[],
-  cursor: { next: string | null },
+  cursor: { next?: string },
 }


### PR DESCRIPTION
Should be `string | undefined` rather than `string | null`