### PR TITLE
Fix incorrect name for `scope`

### DIFF
--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -5,5 +5,5 @@ export type AuthorizationToken = {
   access_token: string;
   token_type: "bearer";
   expires_in: number;
-  scopes: string;
+  scope: string;
 };


### PR DESCRIPTION
The actual value from the API comes through in `scope`, not `scopes`, as per the Oauth2 spec.

@dabrowne do you mind building + publishing this? I'm seeing some TS errors from dependencies:
```
../node_modules/@types/express-serve-static-core/index.d.ts:589:18 - error TS2430: Interface 'Response<ResBody, Locals, StatusCode>' incorrectly extends interface 'ServerResponse'.
  Types of property 'req' are incompatible.
    Type 'Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>> | undefined' is not assignable to type 'IncomingMessage'.
      Type 'undefined' is not assignable to type 'IncomingMessage'.
```

The packages having the problem seem to be at the latest version, so it might be worth pinning whatever versions you have now?