### PR TITLE
used reduce instead of Object.fromEntries which isn't supported on lower es version

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,0 +1,25 @@
+// import MockAdapter from "axios-mock-adapter";
+import { buildUrl, pick } from "../src/utils";
+
+describe("pick", () => {
+  it("returns an object with selected keys from given props", () => {
+    expect(pick({ test: 1, value: 2 }, "value")).toEqual({ value: 2 });
+  });
+});
+
+describe("buildUrl", () => {
+  it("returns a string of the composed url and filters undefined queries", () => {
+    expect(
+      buildUrl({
+        host: "akahu.nz",
+        protocol: "https",
+        query: {
+          test: "1",
+          value: "2",
+          shouldRemove: undefined,
+          anotherValue: "3",
+        },
+      })
+    ).toEqual("https://akahu.nz/?test=1&value=2&anotherValue=3");
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,11 +20,17 @@ export function buildUrl({
 }): string {
   // If not specified, port will be chosen by browser based on protocol choice (http or https).
   const _port = port ? `:${port}` : "";
+  const _query = query || {};
 
   // Clean `undefined` values from the query params
-  const cleanedQuery = Object.fromEntries(
-    Object.entries(query || {}).filter(([_, v]) => typeof v !== "undefined")
-  ) as Record<string, string>;
+  const cleanedQuery = Object.keys(_query).reduce<Record<string, string>>(
+    (accumulator, key) => {
+      const value = _query[key];
+      if (typeof value !== "undefined") accumulator[key] = value;
+      return accumulator;
+    },
+    {}
+  );
 
   // Convert to URL encoded query string
   const queryString =
@@ -39,9 +45,10 @@ export function pick<T extends Record<string, any>>(
   obj: T,
   ...props: string[]
 ): Partial<T> {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([k]) => props.includes(k))
-  ) as Partial<T>;
+  return Object.keys(obj).reduce<Partial<T>>((accumulator, key) => {
+    if (props.includes(key)) accumulator[key as keyof T] = obj[key];
+    return accumulator;
+  }, {});
 }
 
 /**


### PR DESCRIPTION
Changes summary:

- Transformed `Object.entries` and `Object.fromEntries` to `Object.keys` and `Array.reduce` to be more compatible to lower version of ES
- Added tests for the said changes

@wseagar 