### PR TITLE
Update enriched transaction model

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,8 +19,8 @@ It is used to document the dev, build, and deploy workflow and configurations fo
 ## Build and packaging
 The build process consists of two stages that involve both the typescript compiler and
 [rollup](https://rollupjs.org). This process allows us to output both CommonJS and ES Modules, as
-well simplify selection of an appropriate build target (currently `ES2019` for compat with Node.js
-v12.x.x).
+well as simplify selection of an appropriate build target (currently `ES2019` for compat with 
+Node.js v12.x.x).
 
 ### 1. `build:package`
 1. The typescript compiler `tsc` is used to pre-compile the typescript source code to vanilla ES

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,10 @@ akahu - v1.9.0
 
 - [AuthorizationToken](README.md#authorizationtoken)
 
+### Category Type aliases
+
+- [Category](README.md#category)
+
 ### Connection Type aliases
 
 - [Connection](README.md#connection)
@@ -62,8 +66,6 @@ akahu - v1.9.0
 - [TransactionType](README.md#transactiontype)
 - [RawTransaction](README.md#rawtransaction)
 - [PendingTransaction](README.md#pendingtransaction)
-- [PhysicalOutletAddress](README.md#physicaloutletaddress)
-- [WebOutletAddress](README.md#weboutletaddress)
 - [EnrichedTransaction](README.md#enrichedtransaction)
 - [Transaction](README.md#transaction)
 - [TransactionQueryParams](README.md#transactionqueryparams)
@@ -110,6 +112,7 @@ akahu - v1.9.0
 
 - [AccountsResource](classes/AccountsResource.md)
 - [AuthResource](classes/AuthResource.md)
+- [CategoriesResource](classes/CategoriesResource.md)
 - [ConnectionsResource](classes/ConnectionsResource.md)
 - [IdentitiesResource](classes/IdentitiesResource.md)
 - [PartiesResource](classes/PartiesResource.md)
@@ -223,6 +226,22 @@ ___
 | `access_token` | `string` |
 | `token_type` | ``"bearer"`` |
 | `scope` | `string` |
+
+___
+
+## Category Type aliases
+
+### Category
+
+Ƭ **Category**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `_id` | `string` |
+| `name` | `string` |
+| `groups` | `Object` |
 
 ___
 
@@ -698,47 +717,9 @@ ___
 
 ___
 
-### PhysicalOutletAddress
-
-Ƭ **PhysicalOutletAddress**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `pretty` | `string` |
-| `address?` | `Object` |
-| `address.complete?` | `string` |
-| `address.street_number?` | `string` |
-| `address.route?` | `string` |
-| `address.sub_locality?` | `string` |
-| `address.locality?` | `string` |
-| `address.country?` | `string` |
-| `address.postcode?` | `string` |
-| `coordinates?` | `Object` |
-| `coordinates.lat` | `number` |
-| `coordinates.lon` | `number` |
-| `map_image?` | `string` |
-| `accuracy?` | `string` |
-
-___
-
-### WebOutletAddress
-
-Ƭ **WebOutletAddress**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `pretty` | `string` |
-| `url` | `string` |
-
-___
-
 ### EnrichedTransaction
 
-Ƭ **EnrichedTransaction**: [`RawTransaction`](README.md#rawtransaction) & { `outlet`: { `_id`: `string` ; `name`: `string` ; `location?`: [`PhysicalOutletAddress`](README.md#physicaloutletaddress) \| [`WebOutletAddress`](README.md#weboutletaddress)  } ; `merchant`: { `_id`: `string` ; `name`: `string`  } ; `category`: { `_id`: `string` ; `components`: { `name`: `string` ; `type`: `string`  }[]  } ; `meta`: { `particulars?`: `string` ; `code?`: `string` ; `reference?`: `string` ; `other_account?`: `string` ; `conversion?`: `string` ; `logo?`: `string`  }  }
+Ƭ **EnrichedTransaction**: [`RawTransaction`](README.md#rawtransaction) & { `merchant`: { `_id`: `string` ; `name`: `string`  } ; `category`: { `_id`: `string` ; `name`: `string` ; `components`: { `name`: `string` ; `type`: `string`  }[] ; `groups`: { [groupKey: string]: { `_id`: `string` ; `name`: `string`  };  }  } ; `meta`: { `particulars?`: `string` ; `code?`: `string` ; `reference?`: `string` ; `other_account?`: `string` ; `conversion?`: `string` ; `logo?`: `string`  }  }
 
 ___
 

--- a/docs/classes/AkahuClient.md
+++ b/docs/classes/AkahuClient.md
@@ -28,6 +28,7 @@ following two exceptions:
 - [identities](AkahuClient.md#identities)
 - [users](AkahuClient.md#users)
 - [connections](AkahuClient.md#connections)
+- [categories](AkahuClient.md#categories)
 - [accounts](AkahuClient.md#accounts)
 - [payments](AkahuClient.md#payments)
 - [transfers](AkahuClient.md#transfers)
@@ -83,6 +84,14 @@ ___
 
 Utilities to view connections that are available to your app, and refresh
 accounts under a given connection.
+
+___
+
+### categories
+
+• **categories**: [`CategoriesResource`](CategoriesResource.md)
+
+Utilities to view categories that are available to your app.
 
 ___
 

--- a/docs/classes/CategoriesResource.md
+++ b/docs/classes/CategoriesResource.md
@@ -1,0 +1,52 @@
+[akahu - v1.9.0](../README.md) / CategoriesResource
+
+# Class: CategoriesResource
+
+Utilities to view categories that are available to your app.
+
+## Hierarchy
+
+- `BaseResource`
+
+  ↳ **`CategoriesResource`**
+
+## Table of contents
+
+### Methods
+
+- [list](CategoriesResource.md#list)
+- [get](CategoriesResource.md#get)
+
+## Methods
+
+### list
+
+▸ **list**(): `Promise`<[`Category`](../README.md#category)[]\>
+
+List all categories that the app has access to.
+
+[https://developers.akahu.nz/reference/get_categories](https://developers.akahu.nz/reference/get_categories)
+
+#### Returns
+
+`Promise`<[`Category`](../README.md#category)[]\>
+
+___
+
+### get
+
+▸ **get**(`categoryId`): `Promise`<[`Category`](../README.md#category)\>
+
+Get an individual category.
+
+[https://developers.akahu.nz/reference/get_categories-id](https://developers.akahu.nz/reference/get_categories-id)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `categoryId` | `string` |
+
+#### Returns
+
+`Promise`<[`Category`](../README.md#category)\>

--- a/example/index.ts
+++ b/example/index.ts
@@ -42,6 +42,7 @@ const akahu = new AkahuClient({ appToken, appSecret });
   // await identities(); // Comment this out to skip manual identity auth
   await parties(userToken);
   await connections();
+  await categories();
   const userAccounts = await accounts(userToken);
   // await transfers(userToken, userAccounts); // WARNING: THIS EXECUTES TRANSFERS
   // await payments(userToken, userAccounts); // WARNING: THIS EXECUTES PAYMENTS
@@ -149,6 +150,16 @@ async function connections() {
   const connectionId = connections[0]._id;
   const connection = await akahu.connections.get(connectionId);
   console.log(`For example, ${connection.name} ✔️`);
+}
+
+async function categories() {
+  console.log("\n** Testing AkahuClient.categories **");
+  const categories = await akahu.categories.list();
+  console.log(`This app has access to ${categories.length} categories ✔️`);
+
+  const categoryId = categories[0]._id;
+  const category = await akahu.categories.get(categoryId);
+  console.log(`For example, ${category.name} ✔️`);
 }
 
 async function accounts(userToken: string): Promise<Account[]> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ import { AuthResource } from "./resources/auth";
 import { IdentitiesResource } from "./resources/identities";
 import { AccountsResource } from "./resources/accounts";
 import { ConnectionsResource } from "./resources/connections";
+import { CategoriesResource } from "./resources/categories";
 import { PaymentsResource } from "./resources/payments";
 import { TransfersResource } from "./resources/transfers";
 import { TransactionsResource } from "./resources/transactions";
@@ -181,6 +182,11 @@ export class AkahuClient {
   connections: ConnectionsResource;
   /**
    * @category Resource
+   * @inheritDoc CategoriesResource
+   * */
+  categories: CategoriesResource;
+  /**
+   * @category Resource
    * @inheritDoc AccountsResource
    * */
   accounts: AccountsResource;
@@ -277,6 +283,7 @@ export class AkahuClient {
     this.identities = new IdentitiesResource(this);
     this.users = new UsersResource(this);
     this.connections = new ConnectionsResource(this);
+    this.categories = new CategoriesResource(this);
     this.accounts = new AccountsResource(this);
     this.payments = new PaymentsResource(this);
     this.transfers = new TransfersResource(this);

--- a/src/models/categories.ts
+++ b/src/models/categories.ts
@@ -1,0 +1,13 @@
+/**
+ * Akahu category metadata returned by /categories endpoints.
+ */
+export type Category = {
+  _id: string;
+  name: string;
+  groups: {
+    [groupingKey: string]: {
+      _id: string;
+      name: string;
+    };
+  };
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -7,6 +7,9 @@ export { AuthorizationToken } from "./auth";
 /** @category Connection */
 export { Connection } from "./connections";
 
+/** @category Category */
+export { Category } from "./categories";
+
 /** @category Identity */
 export {
   IdentityResult,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -43,8 +43,6 @@ export {
   Transaction,
   PendingTransaction,
   RawTransaction,
-  PhysicalOutletAddress,
-  WebOutletAddress,
   EnrichedTransaction,
   TransactionQueryParams,
 } from "./transactions";

--- a/src/models/transactions.ts
+++ b/src/models/transactions.ts
@@ -107,50 +107,12 @@ export type PendingTransaction = {
 };
 
 /**
- * Outlet location information when the outlet has a physical location.
- */
-export type PhysicalOutletAddress = {
-  pretty: string;
-
-  address?: {
-    complete?: string;
-    street_number?: string;
-    route?: string;
-    sub_locality?: string;
-    locality?: string;
-    country?: string;
-    postcode?: string;
-  };
-
-  coordinates?: {
-    lat: number;
-    lon: number;
-  };
-
-  map_image?: string;
-  accuracy?: string;
-};
-
-/**
- * Outlet location information when the outlet has a web-only presence.
- */
-export type WebOutletAddress = {
-  pretty: string;
-  url: string;
-};
-
-/**
  * A basic transaction with additional enrichment data.
  *
  * An enriched transaction includes structured data describing the merchant
- * and outlet that were party to the transaction.
+ * that was party to the transaction.
  */
 export type EnrichedTransaction = RawTransaction & {
-  outlet: {
-    _id: string;
-    name: string;
-    location?: PhysicalOutletAddress | WebOutletAddress;
-  };
   merchant: { _id: string; name: string };
   category: {
     _id: string;

--- a/src/models/transactions.ts
+++ b/src/models/transactions.ts
@@ -152,7 +152,21 @@ export type EnrichedTransaction = RawTransaction & {
     location?: PhysicalOutletAddress | WebOutletAddress;
   };
   merchant: { _id: string; name: string };
-  category: { _id: string; components: { name: string; type: string }[] };
+  category: {
+    _id: string;
+    name: string;
+    /**
+     * @deprecated
+     * This information is now available in the `groups` attribute.
+     */
+    components: { name: string; type: string }[];
+    groups: {
+      [groupKey: string]: {
+        _id: string;
+        name: string;
+      };
+    };
+  };
   meta: {
     particulars?: string;
     code?: string;

--- a/src/resources/categories.ts
+++ b/src/resources/categories.ts
@@ -1,0 +1,33 @@
+import { BaseResource } from "./base";
+import { Category } from "../models";
+
+/**
+ * Utilities to view categories that are available to your app.
+ *
+ * @category Resource
+ */
+export class CategoriesResource extends BaseResource {
+  /**
+   * List all categories that the app has access to.
+   *
+   * {@link https://developers.akahu.nz/reference/get_categories}
+   */
+  public async list(): Promise<Category[]> {
+    return await this._client._apiCall<Category[]>({
+      path: "/categories",
+      auth: { basic: true },
+    });
+  }
+
+  /**
+   * Get an individual category.
+   *
+   * {@link https://developers.akahu.nz/reference/get_categories-id}
+   */
+  public async get(categoryId: string): Promise<Category> {
+    return await this._client._apiCall<Category>({
+      path: `/categories/${categoryId}`,
+      auth: { basic: true },
+    });
+  }
+}


### PR DESCRIPTION
This consists of:
- Marking `category.components` as deprecated and adding the new `category.groups` model.
- Removing `outlet` from the response. This is not actually returned by the endpoint, and hasn't been for a while.
- Adding `AkahuClient.categories` resource to get categories from the `/categories` endpoint.
