### PR TITLE
Allow idempotency key to be manually specified

### DIFF
--- a/__tests__/client.ts
+++ b/__tests__/client.ts
@@ -3,43 +3,50 @@ import { AkahuClient } from '../src';
 
 
 describe("AkahuClient", () => {
-  let client: any;  // `any` allows access to private methods
+  let client: any; // `any` allows access to private methods
 
   beforeEach(() => {
-    client = new AkahuClient({ appToken: 'app_token_123', appSecret: 'hunter2' });
-  })
+    client = new AkahuClient({
+      appToken: "app_token_123",
+      appSecret: "hunter2",
+    });
+  });
 
   describe("_authorizeRequest()", () => {
     it("does nothing when no auth method specified", async () => {
-      const request = { url: '/test', method: 'post', headers: { DNT: '1' } };
-      
+      const request = { url: "/test", method: "post", headers: { DNT: "1" } };
+
       const authenticatedRequest = client._authorizeRequest(request, undefined);
 
       // Request config is unchanged
       expect(authenticatedRequest).toEqual(request);
     });
-    
+
     it("correctly adds auth token header when specified", async () => {
-      const request = { url: '/test', method: 'post', headers: { DNT: '1' } };
-      
-      const token = 'user_token_123';
+      const request = { url: "/test", method: "post", headers: { DNT: "1" } };
+
+      const token = "user_token_123";
       const authenticatedRequest = client._authorizeRequest(request, { token });
 
       // Authorization header was merged with the request config
-      expect(authenticatedRequest.headers.Authorization).toBe('Bearer user_token_123');
+      expect(authenticatedRequest.headers.Authorization).toBe(
+        "Bearer user_token_123"
+      );
       // All other config values remain untouched
       expect(authenticatedRequest).toMatchObject(request);
     });
 
     it("correctly adds basic auth when specified", async () => {
-      const request = { url: '/test', method: 'post', headers: { DNT: '1' } };
-      
-      const authenticatedRequest = client._authorizeRequest(request, { basic: true });
+      const request = { url: "/test", method: "post", headers: { DNT: "1" } };
+
+      const authenticatedRequest = client._authorizeRequest(request, {
+        basic: true,
+      });
 
       // Authorization header was merged with the request config
       expect(authenticatedRequest.auth).toEqual({
-        username: 'app_token_123',
-        password: 'hunter2'
+        username: "app_token_123",
+        password: "hunter2",
       });
 
       // All other config values remain untouched
@@ -47,27 +54,42 @@ describe("AkahuClient", () => {
     });
   });
 
-  
   describe("_makeIdempotent()", () => {
-    it('adds an Itempotency-Key to all POST requests', () => {
-      const request = { url: '/test', method: 'post', headers: { DNT: '1' } };
+    it("adds an Itempotency-Key to all POST requests", () => {
+      const request = { url: "/test", method: "post", headers: { DNT: "1" } };
 
-      const idempotentRequest = client._makeIdempotent(request);
+      const idempotentRequest = client._makeIdempotent(request, {});
 
       // Idempotency-Key header has been set
-      expect(idempotentRequest.headers['Idempotency-Key']).toBeTruthy();
+      expect(idempotentRequest.headers["Idempotency-Key"]).toBeTruthy();
 
       // All other config values remain untouched
       expect(idempotentRequest).toMatchObject(request);
     });
 
-    it('does not add an Itempotency-Key to all other requests', () => {
-      const request = { url: '/test', method: 'get', headers: { DNT: '1' } };
+    it("adds the proveded Itempotency-Key to a POST request", () => {
+      const request = { url: "/test", method: "post", headers: { DNT: "1" } };
 
-      const idempotentRequest = client._makeIdempotent(request);
+      const idempotentRequest = client._makeIdempotent(request, {
+        idempotencyKey: "my-idempotency-key",
+      });
+
+      // Idempotency-Key header has been set
+      expect(idempotentRequest.headers["Idempotency-Key"]).toBe(
+        "my-idempotency-key"
+      );
+
+      // All other config values remain untouched
+      expect(idempotentRequest).toMatchObject(request);
+    });
+
+    it("does not add an Itempotency-Key to all other requests", () => {
+      const request = { url: "/test", method: "get", headers: { DNT: "1" } };
+
+      const idempotentRequest = client._makeIdempotent(request, {});
 
       // Idempotency-Key header has not been set
-      expect(idempotentRequest.headers['Idempotency-Key']).toBeUndefined();
+      expect(idempotentRequest.headers["Idempotency-Key"]).toBeUndefined();
 
       // All other config values remain untouched
       expect(idempotentRequest).toMatchObject(request);
@@ -75,15 +97,9 @@ describe("AkahuClient", () => {
   });
 });
 
-
-
-
-
-
 describe("AkahuClient._apiCall", () => {
   // let client: AkahuClient;
   // let mockApi: MockAdapter;
-
   // beforeEach(() => {
   //   // Setup a new AkahuClient instance and attach an adapter to mock out axios calls.
   //   client = new AkahuClient({ appToken: 'app_token_123', appSecret: 'hunter2' });

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ akahu - v1.14.0
 
 ### Other Type aliases
 
+- [PostRequestOptions](README.md#postrequestoptions)
 - [Protocol](README.md#protocol)
 
 ### Parties Type aliases
@@ -411,6 +412,20 @@ ___
 ___
 
 ## Other Type aliases
+
+### PostRequestOptions
+
+Ƭ **PostRequestOptions**: `Object`
+
+Additional options for a POST request
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `idempotencyKey?` | `string` | Specifying this key allows you to safely retry POST requests without the risk of taking the same action twice. This is useful when an API call is disrupted in transit and you do not receive a response or you wish to protect against your application issuing duplicate requests.  **`default`** auto generated uuid |
+
+___
 
 ### Protocol
 

--- a/docs/classes/PaymentsResource.md
+++ b/docs/classes/PaymentsResource.md
@@ -70,7 +70,7 @@ ___
 
 ### create
 
-▸ **create**(`token`, `payment`): `Promise`<[`Payment`](../README.md#payment)\>
+▸ **create**(`token`, `payment`, `requestOptions?`): `Promise`<[`Payment`](../README.md#payment)\>
 
 Initiate a payment to an external bank account on behalf of the user associated
 with the specified `token`.
@@ -83,6 +83,7 @@ with the specified `token`.
 | :------ | :------ |
 | `token` | `string` |
 | `payment` | [`PaymentCreateParams`](../README.md#paymentcreateparams) |
+| `requestOptions?` | [`PostRequestOptions`](../README.md#postrequestoptions) |
 
 #### Returns
 
@@ -92,7 +93,7 @@ ___
 
 ### createToIrd
 
-▸ **createToIrd**(`token`, `payment`): `Promise`<[`Payment`](../README.md#payment)\>
+▸ **createToIrd**(`token`, `payment`, `requestOptions?`): `Promise`<[`Payment`](../README.md#payment)\>
 
 Initiate a payment to the Inland Revenue Department on behalf of the user
 associated with the specified `token`.
@@ -105,6 +106,7 @@ associated with the specified `token`.
 | :------ | :------ |
 | `token` | `string` |
 | `payment` | [`IrdPaymentCreateParams`](../README.md#irdpaymentcreateparams) |
+| `requestOptions?` | [`PostRequestOptions`](../README.md#postrequestoptions) |
 
 #### Returns
 

--- a/docs/classes/TransfersResource.md
+++ b/docs/classes/TransfersResource.md
@@ -68,7 +68,7 @@ ___
 
 ### create
 
-▸ **create**(`token`, `transfer`): `Promise`<[`Transfer`](../README.md#transfer)\>
+▸ **create**(`token`, `transfer`, `requestOptions?`): `Promise`<[`Transfer`](../README.md#transfer)\>
 
 Initiate a transfer between two of the users bank accounts.
 
@@ -80,6 +80,7 @@ Initiate a transfer between two of the users bank accounts.
 | :------ | :------ |
 | `token` | `string` |
 | `transfer` | [`TransferCreateParams`](../README.md#transfercreateparams) |
+| `requestOptions?` | [`PostRequestOptions`](../README.md#postrequestoptions) |
 
 #### Returns
 

--- a/docs/classes/WebhooksResource.md
+++ b/docs/classes/WebhooksResource.md
@@ -47,7 +47,7 @@ ___
 
 ### subscribe
 
-▸ **subscribe**(`token`, `webhook`): `Promise`<`string`\>
+▸ **subscribe**(`token`, `webhook`, `requestOptions?`): `Promise`<`string`\>
 
 Subscribe to a webhook.
 
@@ -57,6 +57,7 @@ Subscribe to a webhook.
 | :------ | :------ |
 | `token` | `string` |
 | `webhook` | [`WebhookCreateParams`](../README.md#webhookcreateparams) |
+| `requestOptions?` | [`PostRequestOptions`](../README.md#postrequestoptions) |
 
 #### Returns
 

--- a/src/models/generic.ts
+++ b/src/models/generic.ts
@@ -36,3 +36,19 @@ export type Paginated<T> = {
  * @category Generic
  */
 export type Cursor = string | null | undefined;
+
+
+/**
+ * Additional options for a POST request
+ */
+export type PostRequestOptions = {
+  /**
+   * Specifying this key allows you to safely retry POST requests without the
+   * risk of taking the same action twice. This is useful when an API call is
+   * disrupted in transit and you do not receive a response or you wish to
+   * protect against your application issuing duplicate requests.
+   *
+   * @default auto generated uuid
+   */
+  idempotencyKey?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -78,4 +78,4 @@ export {
   Party,
 } from "./parties";
 
-export { Cursor, Paginated } from "./generic";
+export { Cursor, Paginated, PostRequestOptions } from "./generic";

--- a/src/resources/payments.ts
+++ b/src/resources/payments.ts
@@ -1,5 +1,10 @@
 import { BaseResource } from "./base";
-import { Payment, PaymentCreateParams, PaymentQueryParams } from "../models";
+import {
+  Payment,
+  PaymentCreateParams,
+  PaymentQueryParams,
+  PostRequestOptions,
+} from "../models";
 import { IrdPaymentCreateParams } from "../models/payments";
 
 /**
@@ -49,13 +54,15 @@ export class PaymentsResource extends BaseResource {
    */
   public async create(
     token: string,
-    payment: PaymentCreateParams
+    payment: PaymentCreateParams,
+    requestOptions?: PostRequestOptions
   ): Promise<Payment> {
     return await this._client._apiCall<Payment>({
       path: "/payments",
       method: "POST",
       auth: { token },
       data: payment,
+      options: requestOptions,
     });
   }
 
@@ -67,13 +74,15 @@ export class PaymentsResource extends BaseResource {
    */
   public async createToIrd(
     token: string,
-    payment: IrdPaymentCreateParams
+    payment: IrdPaymentCreateParams,
+    requestOptions?: PostRequestOptions
   ): Promise<Payment> {
     return await this._client._apiCall<Payment>({
       path: "/payments/ird",
       method: "POST",
       auth: { token },
       data: payment,
+      options: requestOptions,
     });
   }
 

--- a/src/resources/transfers.ts
+++ b/src/resources/transfers.ts
@@ -1,5 +1,10 @@
 import { BaseResource } from "./base";
-import { Transfer, TransferCreateParams, TransferQueryParams } from "../models";
+import {
+  Transfer,
+  TransferCreateParams,
+  TransferQueryParams,
+  PostRequestOptions,
+} from "../models";
 
 /**
  * Utilities for managing bank account transfers on behalf of users.
@@ -47,13 +52,15 @@ export class TransfersResource extends BaseResource {
    */
   public async create(
     token: string,
-    transfer: TransferCreateParams
+    transfer: TransferCreateParams,
+    requestOptions?: PostRequestOptions
   ): Promise<Transfer> {
     return await this._client._apiCall<Transfer>({
       path: "/transfers",
       method: "POST",
       auth: { token },
       data: transfer,
+      options: requestOptions,
     });
   }
 }

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -8,6 +8,7 @@ import type {
   WebhookCreateParams,
   WebhookEventQueryParams,
 } from "../models/webhooks";
+import { PostRequestOptions } from "../models";
 
 type CryptoModule = typeof import("crypto");
 
@@ -95,13 +96,15 @@ export class WebhooksResource extends BaseResource {
    */
   public async subscribe(
     token: string,
-    webhook: WebhookCreateParams
+    webhook: WebhookCreateParams,
+    requestOptions?: PostRequestOptions
   ): Promise<string> {
     return await this._client._apiCall<string>({
       path: "/webhooks",
       method: "POST",
       auth: { token },
       data: webhook,
+      options: requestOptions,
     });
   }
 


### PR DESCRIPTION
Adds a new optional `PostRequestOptions` object to relevant API calls