### PR TITLE
Fix for Issue #50: Correct `meta.conversion` type in `EnrichedTransaction` model

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -43,6 +43,7 @@ export {
   Transaction,
   PendingTransaction,
   RawTransaction,
+  CurrencyConversion,
   EnrichedTransaction,
   TransactionQueryParams,
 } from "./transactions";

--- a/src/models/transactions.ts
+++ b/src/models/transactions.ts
@@ -107,6 +107,24 @@ export type PendingTransaction = {
 };
 
 /**
+ * Represents the conversion details of a transaction.
+ */
+export type CurrencyConversion = {
+  /**
+   * The conversion rate used for the transaction.
+   */
+  rate: number,
+  /**
+   * The converted amount in the transaction.
+   */
+  amount: number,
+  /**
+   * The foreign currency in which the transaction was converted to/from.
+   */
+  currency: string
+};
+
+/**
  * A basic transaction with additional enrichment data.
  *
  * An enriched transaction includes structured data describing the merchant
@@ -129,7 +147,7 @@ export type EnrichedTransaction = RawTransaction & {
     code?: string;
     reference?: string;
     other_account?: string;
-    conversion?: string;
+    conversion?: CurrencyConversion;
     logo?: string;
   };
 };


### PR DESCRIPTION
Hello,

This pull request addresses the inconsistency noted in Issue #50. The `meta.conversion` field in the `EnrichedTransaction` model was incorrectly typed as `string?`. According to the API response, this field should be an object with `rate`, `amount`, and `currency` properties.

Changes made:

1. Introduced a new `Conversion` type to represent the conversion details of a transaction.
```typescript
type CurrencyConversion = {
  /**
   * The conversion rate used for the transaction.
   */
  rate: number,
  /**
   * The converted amount in the transaction.
   */
  amount: number,
  /**
   * The foreign currency in which the transaction was converted to/from.
   */
  currency: string
};
```

2. Updated the `EnrichedTransaction` type to use the `Conversion` type for the `meta.conversion` field.
```typescript
type EnrichedTransaction = RawTransaction & {
  // ...
  meta: {
    // ...
    conversion?: Conversion;
    // ...
  };
};
```

3. Updated the documentation, adding a `CurrencyConversion` section, and altering `EnrichedTransaction` to match the type changes.

Please review and let me know if any changes are required.

Fixes #50

Cheers